### PR TITLE
[G15_5511 branch] Options for disabling RGB and logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,12 +75,13 @@ class MainWindow(QWidget):
         self.shell.expect("[#$] ")
         self.shell_exec(" export HISTFILE=/dev/null; history -c")
         # Check if user is member of plugdev
-        self.is_plugdev = (self.shell_exec("groups")[1].find("plugdev") != -1)
-        if self.is_plugdev:
-            print("User is member of group of plugdev.")
-        else:
-            choice = QMessageBox.question(self,"Warning","User is not a member of group plugdev. Try to enable keyboard backlight control anyway?",QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
-            self.is_plugdev = (choice == QMessageBox.StandardButton.Yes) #User override
+        self.is_plugdev = False #(self.shell_exec("groups")[1].find("plugdev") != -1)
+        #if self.is_plugdev:
+        #    print("User is member of group of plugdev.")
+        #else:
+        #    choice = QMessageBox.question(self,"Warning","User is not a member of group plugdev. Try to enable keyboard backlight control anyway?",QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        #    self.is_plugdev = (choice == QMessageBox.StandardButton.Yes) #User override
+
         #Elevate privileges (pkexec is needed)
         self.shell_exec("pkexec bash --noprofile --norc")
         self.shell_exec(" export HISTFILE=/dev/null; history -c")
@@ -104,7 +105,7 @@ class MainWindow(QWidget):
     def checkLaptapModel(self):
         # Check laptop model and inform user if model is not supported.
         commands = {
-            5511: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", g15_5511_patch),
+            5511: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", None), # g15_5511_patch),
             5520: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", g15_5520_patch),
             5525: ("echo \"\\_SB.AMW3.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", None),
         }

--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ class MainWindow(QWidget):
     def checkLaptapModel(self):
         # Check laptop model and inform user if model is not supported.
         commands = {
-            5511: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", None), # g15_5511_patch),
+            5511: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", g15_5511_patch),
             5520: ("echo \"\\_SB.AMWW.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", g15_5520_patch),
             5525: ("echo \"\\_SB.AMW3.WMAX 0 {} {{{}, {}, {}, 0x00}}\" > /proc/acpi/call; cat /proc/acpi/call", None),
         }

--- a/patch.py
+++ b/patch.py
@@ -3,10 +3,12 @@ def g15_5520_patch(wind):
     
 def g15_5511_patch(wind):
     wind.power_modes_dict = {
-        "Quiet" : "0x96",
-        "Balanced" : "0x97",
-        "Performance" : "0x98",
-        "FullSpeed" : "0x99",
+        "Balanced" : "0xa0",
+        "Performance" : "0xa1",
+        "Cool" : "0xa2",
+        "Quiet" : "0xa3",
+       #"USTT_FullSpeed" : "0xa4", # Hidden for 5511
+       #"USTT_BatterySaver" : "0xa5", Hidden for 5511
         "G Mode" : "0xab",
         "Manual" : "0x0",
     }


### PR DESCRIPTION
For those "unlucky" having G15 model without RGB keyboard, with single color backlight only, RGB functions are unnecessary, generating trash and nagging to log file.

Also, the whole logging thing is unnecessary, after everything is tested to work properly, so I've added option to disable it, together with option to change log file path.

Everything is being set out of Class MainWindow, so I don't know how much "clean" is it, using global variables, but feel free to reimplement it in programitally cleaner way. My solution seems neat to me in a way, Settings is in top of the file.

Maybe It would be even better to create separate settings.py file and import variables from there.

Currently it's in a form like this:

_########
#Settings#
#######
rgb_keyboard = False
log = False
logpath = '/tmp/dellg15controller.log'
###########
###########
###########_