### PR TITLE
Remove plugdev in favor of uaccess

### DIFF
--- a/00-aw-elc.rules
+++ b/00-aw-elc.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0660", GROUP="plugdev", SYMLINK+="awelc"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0660", TAG+="uaccess", SYMLINK+="awelc"

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Only static color and morph is supported at this time.
 
 ## Installation
 
-Create an udev rule ```/etc/udev/rules.d/00-aw-elc.rules```. Make sure the user is part of the ```plugdev``` group.
+Create an udev rule ```/etc/udev/rules.d/00-aw-elc.rules```.
 
 ```
 /etc/udev/rules.d/00-aw-elc.rules
 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0660", GROUP="plugdev", SYMLINK+="awelc"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0660", TAG+="uaccess", SYMLINK+="awelc"
 ```
 
 Polkit is required for power and fan related functionality. If it is not already loaded, load the acpi_call module before launching this application.

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from patch import g15_5520_patch
 from patch import g15_5515_patch
 from patch import g15_5511_patch
 
-
 class MainWindow(QWidget):
 
     def __init__(self, parent=None):
@@ -33,8 +32,7 @@ class MainWindow(QWidget):
         #Create grid layout
         grid = QGridLayout()
         self.timer = None
-        if (self.is_plugdev):
-            grid.addWidget(self.createFirstExclusiveGroup(), 0, 0)
+        grid.addWidget(self.createFirstExclusiveGroup(), 0, 0)
         if (self.is_root and self.is_dell_g15):
             grid.addWidget(self.createSecondExclusiveGroup(), 0, 1)
             self.timer = QTimer(self)    #timer to update fan rpm values
@@ -75,13 +73,6 @@ class MainWindow(QWidget):
         self.shell = pexpect.spawn('bash', encoding='utf-8', logfile=self.logfile, env=None, args=["--noprofile", "--norc"])
         self.shell.expect("[#$] ")
         self.shell_exec(" export HISTFILE=/dev/null; history -c")
-        # Check if user is member of plugdev
-        self.is_plugdev = (self.shell_exec("groups")[1].find("plugdev") != -1)
-        if self.is_plugdev:
-            print("User is member of group of plugdev.")
-        else:
-            choice = QMessageBox.question(self,"Warning","User is not a member of group plugdev. Try to enable keyboard backlight control anyway?",QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
-            self.is_plugdev = (choice == QMessageBox.StandardButton.Yes) #User override
         #Elevate privileges (pkexec is needed)
         self.shell_exec("pkexec bash --noprofile --norc")
         self.shell_exec(" export HISTFILE=/dev/null; history -c")


### PR DESCRIPTION
rationale: having a plugdev group is considered a bug by Arch Linux, and the group does not exist by default
See https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices

This will work for any user that is logged in.